### PR TITLE
Reactivate ls colors

### DIFF
--- a/zsh/.aliases
+++ b/zsh/.aliases
@@ -1,3 +1,4 @@
+alias ls='ls -G --color'
 alias ll='ls -lahF'
 alias ptg='git push origin HEAD:refs/for/master'
 alias git='LANG=en_GB git'


### PR DESCRIPTION
For whatever reason the colored output in the ls command was gone. After
trying various things, calling ls with the --color option did the trick.
Not sure why this wasn't the case before. It doesn't look like any aliases
(oh-my-zsh, tmux, ...) have changed in the meantime.