### PR TITLE
Start vscode from command line

### DIFF
--- a/zsh/.aliases
+++ b/zsh/.aliases
@@ -6,6 +6,9 @@ alias weekly="git log --oneline --author 'Felix' --since=1.weeks --no-merges"
 alias sourcetree='open -a SourceTree ./'
 alias pr='hub pull-request'
 
+# Always start VS Code in the current directory by default
+alias code='code .'
+
 # Custom tree commands
 alias tree="tree -F"
 # python repositories

--- a/zsh/.exports
+++ b/zsh/.exports
@@ -1,5 +1,7 @@
 # Define basic path variable
 export PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+# Add VS Code to the path (binary: code)
+export PATH=/Applications/Visual\ Studio\ Code.app/Contents/Resources/app/bin:${PATH}
 # Add GNU core utils to path (take precedence over FreeBSD commands)
 export PATH=/opt/local/libexec/gnubin:${PATH}
 # Add MacPorts to path


### PR DESCRIPTION
38e7cd1 (Felix Schmidt, 46 seconds ago)
   vscode: Alias to start vscode in the current directory by default

dc4200c (Felix Schmidt, 73 seconds ago)
   vscode: Add vscode binary to PATH to enable start from command line