### PR TITLE
vscode: Include pythonPath, black and flake8 in global config, restructure config keys

### DIFF
--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -1,14 +1,13 @@
 {
-    "[python]": {},
+    "editor.fontFamily": "Fira Code",
+    "editor.fontLigatures": true,
+    "editor.minimap.enabled": false,
     "files.insertFinalNewline": true,
     "files.trimTrailingWhitespace": true,
-    "python.jediEnabled": true,
     "python.pythonPath": ".tox/dev/bin/python",
+    "python.jediEnabled": true,
     "python.formatting.provider": "black",
     "python.formatting.blackPath": "~/.virtualenvs/tools/bin/black",
     "python.linting.flake8Enabled": true,
-    "python.linting.flake8Path": "~/.virtualenvs/tools/bin/flake8",
-    "editor.minimap.enabled": false,
-    "editor.fontFamily": "Fira Code",
-    "editor.fontLigatures": true
+    "python.linting.flake8Path": "~/.virtualenvs/tools/bin/flake8"
 }

--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -5,6 +5,8 @@
     "python.jediEnabled": true,
     "python.formatting.provider": "black",
     "python.formatting.blackPath": "~/.virtualenvs/tools/bin/black",
+    "python.linting.flake8Enabled": true,
+    "python.linting.flake8Path": "~/.virtualenvs/tools/bin/flake8",
     "editor.minimap.enabled": false,
     "editor.fontFamily": "Fira Code",
     "editor.fontLigatures": true

--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -3,6 +3,8 @@
     "files.insertFinalNewline": true,
     "files.trimTrailingWhitespace": true,
     "python.jediEnabled": true,
+    "python.formatting.provider": "black",
+    "python.formatting.blackPath": "~/.virtualenvs/tools/bin/black",
     "editor.minimap.enabled": false,
     "editor.fontFamily": "Fira Code",
     "editor.fontLigatures": true

--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -3,6 +3,7 @@
     "files.insertFinalNewline": true,
     "files.trimTrailingWhitespace": true,
     "python.jediEnabled": true,
+    "python.pythonPath": ".tox/dev/bin/python",
     "python.formatting.provider": "black",
     "python.formatting.blackPath": "~/.virtualenvs/tools/bin/black",
     "python.linting.flake8Enabled": true,


### PR DESCRIPTION
Changes:

4bfad7b (Felix Schmidt, 46 seconds ago)
   vscode: Restructure global settings

5eea60f (Felix Schmidt, 8 minutes ago)
   vscode: Set default python path in global config

   Currently, vscode is complaining for every new project about the missing 
   python path. So let's define the path that matches most of the projects as
   default. If it doesn't work for a specific project, we might overwrite it
   in that project's workspace config.

d628387 (Felix Schmidt, 9 minutes ago)
   vscode: Activate flake8 with custom path in global config

0e57b4b (Felix Schmidt, 9 minutes ago)
   vscode: Activate black with custom path in global config