### PR TITLE
Improve some vscode settings for python

### DIFF
--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -18,7 +18,6 @@
     "search.showLineNumbers": true,
     "vim.statusBarColorControl": true,
     "workbench.settings.editor": "json",
-    "workbench.settings.useSplitJSON": true,
     "workbench.colorCustomizations": {
         "statusBar.background": "#005f5f",
         "statusBar.noFolderBackground": "#005f5f",

--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -7,6 +7,8 @@
     "editor.minimap.enabled": false,
     "files.insertFinalNewline": true,
     "files.trimTrailingWhitespace": true,
+    "outline.showVariables": false,
+    "outline.showModules": false,
     "python.pythonPath": ".tox/dev/bin/python",
     "python.jediEnabled": true,
     "python.formatting.provider": "black",

--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -1,4 +1,7 @@
 {
+    "[python]": {
+        "editor.rulers": [79, 120],
+    },
     "editor.fontFamily": "Fira Code",
     "editor.fontLigatures": true,
     "editor.minimap.enabled": false,


### PR DESCRIPTION
Changes:

d51081b (Felix Schmidt, 2 minutes ago)
   vscode: Deactivate split view for workspace settings

   I usually already have an active split view and thus the splitted settings
   view results in two very narrow windows.

70c052d (Felix Schmidt, 34 minutes ago)
   vscode: Hide variables and modules in code outline

   For larger files, those fill up the outline quite heavily and in most cases
   don't provide too much information.

a4d16ee (Felix Schmidt, 35 minutes ago)
   vscode: Enable editor rulers (vertical lines) for python files