### PR TITLE
vscode: Prevent file explorer from jumping to the active file

### DIFF
--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -5,6 +5,7 @@
     "editor.fontFamily": "Fira Code",
     "editor.fontLigatures": true,
     "editor.minimap.enabled": false,
+    "explorer.autoReveal": false,
     "files.insertFinalNewline": true,
     "files.trimTrailingWhitespace": true,
     "outline.showVariables": false,


### PR DESCRIPTION
It's annoying when you just want to check some file contents and
whenever you close a file, the file explorer jumps to the next active
file.